### PR TITLE
glinet_gl-mt300n-v2: allow to use I2C and UART1 pins as GPIO

### DIFF
--- a/target/linux/ramips/dts/mt7628an_glinet_gl-mt300n-v2.dts
+++ b/target/linux/ramips/dts/mt7628an_glinet_gl-mt300n-v2.dts
@@ -75,7 +75,7 @@
 
 &state_default {
 	gpio {
-		groups = "wdt", "gpio", "wled_an", "p0led_an", "p1led_an", "i2s";
+		groups = "wdt", "gpio", "wled_an", "p0led_an", "p1led_an", "i2s", "i2c", "uart1";
 		function = "gpio";
 	};
 };


### PR DESCRIPTION
The [documentation](https://docs.gl-inet.com/en/3/specification/gl-mt300n-v2/#pcb-pinout) for the GL-MT300N-V2 (Mango) from GL.iNet 
explicitly encourages users to uitlize the I2C and UART1 pins as GPIO4, GPIO5, GPIO45 and GPIO46. 
The gl-inet fork of OpenWrt [already supports this](https://github.com/gl-inet/openwrt/commit/8b2cb84b01d570aec1a7f87f09aac528347f568e), but still defaults to OpenWrt 19.07.
This patch enables the feature so users may use it in latest upstream OpenWrt version.